### PR TITLE
Allow query param in toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,17 @@ Here's a *example.toml* file (using [httpbin](https://httpbin.org)):
 ```toml
 url = "http://httpbin.org/get"
 method = "GET"
+[params]
+key1="value1"
 ```
 
 ```
 $ treqs example.toml
 
 {
-  "args": {},
+  "args": {
+    "key1": "value1"
+  },
   "headers": {
     "Accept": "*/*",
     "Accept-Encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
@@ -30,7 +34,7 @@ $ treqs example.toml
     "X-Amzn-Trace-Id": "Root=1-61cef5f2-4d3838d5301ed2a930e4da5d"
   },
   "origin": "185.114.123.86",
-  "url": "http://httpbin.org/get"
+  "url": "http://httpbin.org/get?key1=value1"
 }
 ```
 
@@ -63,7 +67,7 @@ src/
 
 README.md
 
-requets/
+requests/
   get_user.toml
   create_user.toml
   list_all_items.toml

--- a/lib/treqs/checker.rb
+++ b/lib/treqs/checker.rb
@@ -6,7 +6,7 @@ module Checker
   class ExtraKeysError < StandardError; end
 
   REQUIRED_KEYS = %w[url method].to_set
-  EXTRA_KEYS = %w[headers body].to_set
+  EXTRA_KEYS = %w[headers body params].to_set
 
   # @param [Hash]
   # @raise [Checker::RequiredKeysError]

--- a/lib/treqs/config.rb
+++ b/lib/treqs/config.rb
@@ -2,7 +2,7 @@
 
 # Class containing the request information
 class Config
-  attr_reader :method, :url, :headers, :body
+  attr_reader :method, :url, :headers, :body, :params
 
   # @param [Hash]
   def initialize(config_hash)
@@ -10,5 +10,6 @@ class Config
     @url = URI(config_hash['url'])
     @headers = config_hash['headers']
     @body = config_hash['body']
+    @params = config_hash['params']
   end
 end

--- a/lib/treqs/requestor.rb
+++ b/lib/treqs/requestor.rb
@@ -12,7 +12,8 @@ module Requestor
   def call(config)
     conn = Faraday.new(
       url: config.url,
-      headers: config.headers
+      headers: config.headers,
+      params: config.params
     )
 
     case config.method


### PR DESCRIPTION
With this feature, we will be able to send query params without having to change the url.

To produce `http://httpbin.org/get?ke1=value1`, the toml file will be like this:

```toml
url = "http://httpbin.org/get"
method = "GET"
[params]
key1="value1"
```